### PR TITLE
Sane numpy matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "NneO1eRrU+SD4hS9dPaDSGHhY66FDwqvRYEt0TaTjigQMLbZzwwJI2F7lvLDr6sVzxRAR/c/YEkYESJ/zFW4Jt8TfRD10pR7viHc2ODlA1Ym1eknQBw3ijyYAL3Ms+FlyKXozAzjBp1/FqwLbP36S+mkej9XjTZivQQ5MbspA6cH4g01Hte8lupPyXoh36mrvAIAFx+TWJFxSIx4szFvahK3FmqjsQ1SoWF0+kQpsik4vAg92NZQqfSM0r5qmUzOGGv6P52wx0+H6AgWDNeak2LFxlOXhxouLHAhZvK869dSLvpNfoCiHgrm26uKZdwLVVIeMPBMVDwVKu52hMNDlSx+fcMxQP/u5oUWiu6G54RSog1n320BYZQ/CFoqJL28+MjQYVvA03nNMCnYQAZWZmuxNSqpbso7TQfsbi2iGYubfddy73D7mn0O4PECKW6XNVaarzXoiNk6mkgj08RJIEBTWb/+skqNGZxqTZsFs1vqPEhslysBRvT9Sy1F90824w3Rsd9lpi3jZT1YN/qftG7yFgqgo4PfxcIrpWmi9DFAenNmzyasuJ9QykLPW0NU2m53wOjIeHcCukaCmdtrcxVZTJ3+wG6vAa1UwzREIFXdI0EHbLFIR2biA8A3cJDVMDnZwUkBWmeHtGnnvgrTb97/cT3fUX2Dn473CwaoK0c="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,44 +57,20 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 6 case(s).
+# Embarking on 3 case(s).
     set -x
-    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=112
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - python
     - setuptools
-    - cython
+    - cython 0.25.2
     - numpy 1.8.*
     - embree
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:
@@ -22,11 +22,11 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy x.x
+    - numpy 1.8.*
     - embree
   run:
     - python
-    - numpy x.x
+    - numpy >=1.8
     - embree
 
 test:
@@ -44,3 +44,4 @@ extra:
   recipe-maintainers:
     - scopatz
     - Xarthisius
+    - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,9 @@ requirements:
 test:
   imports:
     - pyembree
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: https://github.com/scopatz/pyembree


### PR DESCRIPTION
Latest build was with `np111`, causing massive downgrades when installing `pyembree` with other packages. This PR will ensure that we build with an old enough `numpy` but run with any backwards compatible version available in `conda-forge`.

This will also help a lot with the `yt` instalation. (ping @ngoldbaum)

(And we don't need to rebuild it every time a new `numpy` is released.)